### PR TITLE
【マージ不要】グローバルState管理未使用の例

### DIFF
--- a/src/components/atoms/button/SecondaryButton.jsx
+++ b/src/components/atoms/button/SecondaryButton.jsx
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 import { BaseButton } from './BaseButton';
 
 export const SecondaryButton = (props) => {
-  const { children } = props;
-  return <SButton>{children}</SButton>;
+  const { children, onClick } = props;
+  return <SButton onClick={onClick}>{children}</SButton>;
 };
 
 const SButton = styled(BaseButton)`

--- a/src/components/molecules/user/UserIconWithName.jsx
+++ b/src/components/molecules/user/UserIconWithName.jsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 
 export const UserIconWithName = (props) => {
-  const { image, name } = props;
+  const { image, name, isAdmin } = props;
   return (
     <Scontainer>
       <Simg src={image} alt='プロフィール' width={160} height={160} />
       <SName>{name}</SName>
+      {isAdmin && <SEdit>編集</SEdit>}
     </Scontainer>
   );
 };
@@ -23,4 +24,10 @@ const SName = styled.p`
   font-weight: bold;
   margin: 0;
   color: #40514e;
+`;
+
+const SEdit = styled.span`
+  text-decoration: underline;
+  color: #aaa;
+  cursor: pointer;
 `;

--- a/src/components/organisms/user/UserCard.jsx
+++ b/src/components/organisms/user/UserCard.jsx
@@ -3,10 +3,10 @@ import { Card } from '../../atoms/card/Card';
 import { UserIconWithName } from '../../molecules/user/UserIconWithName';
 
 export const UserCard = (props) => {
-  const { user } = props;
+  const { user, isAdmin } = props;
   return (
     <Card>
-      <UserIconWithName image={user.image} name={user.name} />
+      <UserIconWithName image={user.image} name={user.name} isAdmin={isAdmin}/>
       <SDl>
         <dt>メール</dt>
         <dd>{user.email}</dd>

--- a/src/components/pages/Top.jsx
+++ b/src/components/pages/Top.jsx
@@ -1,10 +1,22 @@
+import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { SecondaryButton } from '../atoms/button/SecondaryButton';
+
 export const Top = () => {
+  const history = useHistory();
+  const onClickAdmin = () =>
+    history.push({ pathname: 'users', state: { isAdmin: true } });
+  const onClickGeneral = () =>
+    history.push({ pathname: 'users', state: { isAdmin: false } });
   return (
     <div>
       <SContainer>
         <h2>TOPページです</h2>
+        <SecondaryButton onClick={onClickAdmin}>管理者ユーザー</SecondaryButton>
+        <br />
+        <br />
+        <SecondaryButton onClick={onClickGeneral}>一般ユーザー</SecondaryButton>
       </SContainer>
     </div>
   );

--- a/src/components/pages/Users.jsx
+++ b/src/components/pages/Users.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { SearchInput } from '../molecules/SearchInput';
 import { UserCard } from '../organisms/user/UserCard';
+import { useLocation } from 'react-router-dom';
 
 // 表示確認のためにオブジェクトを10個生成
 const users = [...Array(10).keys()].map((val) => {
@@ -18,6 +19,8 @@ const users = [...Array(10).keys()].map((val) => {
 });
 
 export const Users = () => {
+  const { state } = useLocation();
+  const isAdmin = state ? state.isAdmin : false;
   return (
     <div>
       <SContainer>
@@ -25,7 +28,7 @@ export const Users = () => {
         <SearchInput />
         <SUserArea>
           {users.map((user) => (
-            <UserCard {...{ user }} />
+            <UserCard key={user.id} {...{ user, isAdmin }}  />
           ))}
         </SUserArea>
       </SContainer>


### PR DESCRIPTION
* globalなState管理が無い場合、例えば「管理者ユーザーの場合のみ編集リンクを表示する」といった単純な要件の実装でも、isAdminフラグを何箇所もバケツリレーしなければならない、それはシンドい